### PR TITLE
fix: ERROR: environment variable name 'FLINK_HOST ' may not contain whitespace.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,7 +111,7 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
       - SPRING_DATA_CASSANDRA_CONTACT_POINTS=cassandra
       - SPRING_DATA_CASSANDRA_PORT=9042
-      - FLINK_HOST = localhost
+      - FLINK_HOST=localhost
     ports:
       - "8086:8086"
   ui-earthquake:


### PR DESCRIPTION
I was facing this issue on my Linux env.
![image](https://github.com/user-attachments/assets/0959dab1-267f-41c2-81f1-37b103f3c754)